### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 3.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 2.1 (2025-04-09)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 CHANGES
 =======
 
-2.2 (unreleased)
+3.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*rnames):
 
 setup(
     name='z3c.password',
-    version='2.2.dev0',
+    version='3.0.dev0',
     author="Stephan Richter, Roger Ineichen and the Zope Community",
     author_email="zope-dev@zope.dev",
     description="Password generation and verification utility for Zope3",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 ##############################################################################
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -54,10 +53,7 @@ setup(
         'Framework :: Zope :: 3',
     ],
     url='https://github.com/zopefoundation/z3c.password',
-    packages=find_packages('src'),
     include_package_data=True,
-    package_dir={'': 'src'},
-    namespace_packages=['z3c'],
     python_requires='>=3.9',
     extras_require=dict(
         test=[

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
